### PR TITLE
cortex-m-rtfm became cortex-m-rtic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ cortex-m = "0.6.0"
 cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
-cortex-m-rtfm = "0.5.1"
+cortex-m-rtic = "0.5.5"
 
 [dependencies.stm32l0]
 version = "0.9.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate panic_halt;
 use stm32l0xx_hal::gpio::{gpiob::PB11, Output, PushPull};
 use stm32l0xx_hal::{prelude::*, rcc, timer::Timer};
 
-#[rtfm::app(device=stm32l0::stm32l0x3, peripherals=true)]
+#[rtic::app(device=stm32l0::stm32l0x3, peripherals=true)]
 const APP: () = {
     struct Resources {
         status_led: PB11<Output<PushPull>>,


### PR DESCRIPTION
Fixes warning:
  use of deprecated item 'init': cortex-m-rtfm has been renamed
  and is deprecated, use cortex-m-rtic instead.